### PR TITLE
Include /usr/local/bin & sbin in path for all hooks

### DIFF
--- a/main_hook.go
+++ b/main_hook.go
@@ -113,7 +113,8 @@ func GitSeekretHookEnable(name string) error {
 	}
 	defer fh.Close()
 
-	fh.WriteString("#!/usr/bin/env bash\n\n")
+	fh.WriteString("#!/usr/bin/env bash\n")
+	fh.WriteString("PATH=$PATH:/usr/local/bin:/usr/local/sbin\n\n")
 	fh.WriteString(script)
 	fh.Close()
 


### PR DESCRIPTION
Since a natural install location for git-seekret is in `/usr/local/bin` we make sure our hooks always have that in our path just in case the user doesn't already.