### PR TITLE
Build updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      before_install:
+      install:
         - sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ xenial main restricted universe" >> /etc/apt/sources.list'
         - sudo apt-get update -qq
         - sudo apt-get install -y pkg-config libgit2-dev cmake shellcheck
     - os: osx
       osx_image: xcode8.1
-      before_install:
+      install:
         - brew install pkg-config libgit2 cmake shellcheck glide
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ script:
   - ./releases/git-seekret-*
   - go test -tags static $(glide nv)
 
+addons:
+  artifacts:
+    s3_region: "us-gov-west-1" # defaults to "us-east-1"
+    paths: $(ls releases/git-seekret-* | tr "\n" ":")
+
 # before_deploy:
 #   - export RELEASE_FILE=$(ls releases/git-seekret-*)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,23 @@ matrix:
       before_install:
         - brew install pkg-config libgit2 cmake shellcheck glide
 
-script:
+install:
   - shellcheck build.sh
   - ./build.sh
-  - go test $(glide nv)
+
+script:
+  - ./releases/git-seekret-*
+  - go test -tags static $(glide nv)
+
+# before_deploy:
+#   - export RELEASE_FILE=$(ls releases/git-seekret-*)
+
+# deploy:
+#   provider: releases
+#   api_key: GITHUB_API_KEY_GOES_HERE
+#   file_glob: true
+#   file: "${RELEASE_FILE}"
+#   skip_cleanup: true
+#   overwrite: true
+#   on:
+#     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,11 @@ matrix:
       install:
         - sudo sh -c 'echo "deb http://archive.ubuntu.com/ubuntu/ xenial main restricted universe" >> /etc/apt/sources.list'
         - sudo apt-get update -qq
-        - sudo apt-get install -y pkg-config libgit2-dev cmake shellcheck
+        - sudo apt-get install -y pkg-config cmake shellcheck
     - os: osx
       osx_image: xcode8.1
       install:
-        - brew install pkg-config libgit2 cmake shellcheck glide
+        - brew install pkg-config cmake shellcheck glide
 
 script:
   - shellcheck build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,9 @@ matrix:
       before_install:
         - brew install pkg-config libgit2 cmake shellcheck glide
 
-install:
+script:
   - shellcheck build.sh
   - ./build.sh
-
-script:
-  - ./releases/git-seekret-*
-  - go test -tags static $(glide nv)
 
 addons:
   artifacts:

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ function compile_libssh() {
   export PKG_CONFIG_PATH="${RELEASE_PATH}/openssl/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSL_PCFILE="${RELEASE_PATH}/openssl/lib/pkgconfig/libssl.pc"
   export LIBCRYPTO_PCFILE="${RELEASE_PATH}/openssl/lib/pkgconfig/libcrypto.pc"
-  ./configure --disable-shared --prefix="${RELEASE_PATH}/libssh2"
+  ./configure --disable-shared --with-libssl-prefix="${RELEASE_PATH}/openssl" --prefix="${RELEASE_PATH}/libssh2"
   make && make install
   popd
 }
@@ -57,7 +57,7 @@ function compile_libcurl() {
   pushd curl-${LIBCURLVER}
   export PKG_CONFIG_PATH="${RELEASE_PATH}/libssh2/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSH2_PCFILE="${RELEASE_PATH}/libssh2/lib/pkgconfig/libssh2.pc"
-  ./configure --with-ssl --with-libssh2 --disable-shared --prefix="${RELEASE_PATH}/curl"
+  ./configure --with-ssl --with-libssh2 --without-librtmp --disable-ldap --disable-shared --prefix="${RELEASE_PATH}/curl"
   make && make install
   popd
 }
@@ -144,7 +144,19 @@ function compile_git_seekrets() {
   echo
 }
 
+function test_git_seekrets() {
+  echo
+  echo "Trying to run git-seekret.."
+  "${RELEASE_PATH}"/git-seekret-* || exit 1
+  echo
+  echo "Running tests.."
+  go test -tags static "$(glide nv)"
+  echo
+  echo "..All Done"
+}
+
 rm -rf "$RELEASE_PATH"
 mkdir -p "$RELEASE_PATH"
 
 compile_git_seekrets
+test_git_seekrets

--- a/build.sh
+++ b/build.sh
@@ -7,10 +7,64 @@
 # a GitHub Release for them to be publiclly accessible.
 set -e
 
-LIBGITVER="0.25.0"
+LIBGITVER="0.25.1"
+LIBSSHVER="1.8.0"
+LIBCURLVER="7.52.1"
+OPENSSLVER="1.0.2j"
+
 RELEASE_PATH=$(pwd)/releases
 
+function compile_openssl() {
+  rm -rf openssl-${OPENSSLVER}
+  if [ ! -f openssl-1.0.2j.tar.gz ]; then
+    curl -L -o openssl-${OPENSSLVER}.tar.gz https://www.openssl.org/source/openssl-${OPENSSLVER}.tar.gz
+  fi
+  tar -xvf openssl-${OPENSSLVER}.tar.gz
+  pushd openssl-${OPENSSLVER}
+  export KERNEL_BITS=64
+  ./config no-shared no-ssl2 no-ssl3 --prefix=${RELEASE_PATH}/openssl --openssldir=${RELEASE_PATH}/openssl
+  make depend && make
+  make install
+  popd
+}
+
+function compile_libssh() {
+  compile_openssl
+
+  rm -rf libssh2-${LIBSSHVER}
+
+  if [ ! -f libssh2-${LIBSSHVER}.tar.gz ]; then
+    curl -L -o libssh2-${LIBSSHVER}.tar.gz https://www.libssh2.org/download/libssh2-${LIBSSHVER}.tar.gz
+  fi
+  tar -xzf libssh2-${LIBSSHVER}.tar.gz
+  pushd libssh2-${LIBSSHVER}
+  export PKG_CONFIG_PATH="${RELEASE_PATH}/openssl/lib/pkgconfig:${PKG_CONFIG_PATH}"
+  export LIBSSL_PCFILE="${RELEASE_PATH}/openssl/lib/pkgconfig/libssl.pc"
+  export LIBCRYPTO_PCFILE="${RELEASE_PATH}/openssl/lib/pkgconfig/libcrypto.pc"
+  ./configure --disable-shared --prefix="${RELEASE_PATH}/libssh2"
+  make && make install
+  popd
+}
+
+function compile_libcurl() {
+  compile_libssh
+
+  rm -rf curl-${LIBCURLVER}
+  if [ ! -f curl-${LIBCURLVER}.tar.gz ]; then
+    curl -L -o curl-${LIBCURLVER}.tar.gz https://curl.haxx.se/download/curl-${LIBCURLVER}.tar.gz
+  fi
+  tar -xvf curl-${LIBCURLVER}.tar.gz
+  pushd curl-${LIBCURLVER}
+  export PKG_CONFIG_PATH="${RELEASE_PATH}/libssh2/lib/pkgconfig:${PKG_CONFIG_PATH}"
+  export LIBSSH2_PCFILE="${RELEASE_PATH}/libssh2/lib/pkgconfig/libssh2.pc"
+  ./configure --with-ssl --with-libssh2 --disable-shared --prefix=${RELEASE_PATH}/curl
+  make && make install
+  popd
+}
+
 function compile_libgit() {
+  compile_libcurl
+
   rm -rf "$RELEASE_PATH/libgit2"
   rm -rf libgit2-${LIBGITVER}
   if [ ! -f libgit2-${LIBGITVER}.tar.gz ]; then
@@ -18,13 +72,16 @@ function compile_libgit() {
   fi
   tar -xzf libgit2-${LIBGITVER}.tar.gz
   mkdir -p libgit2-${LIBGITVER}/build
-  (cd libgit2-${LIBGITVER}/build \
-    && cmake -DTHREADSAFE=ON \
+  export PKG_CONFIG_PATH="${RELEASE_PATH}/curl/lib/pkgconfig:${PKG_CONFIG_PATH}"
+  export LIBCURL_PCFILE="${RELEASE_PATH}/curl/lib/pkgconfig/libcurl.pc"
+  pushd libgit2-${LIBGITVER}/build
+  cmake -DTHREADSAFE=ON \
         -DBUILD_CLAR=OFF \
         -DBUILD_SHARED_LIBS=OFF \
         -DCMAKE_C_FLAGS=-fPIC \
-        -DCMAKE_INSTALL_PREFIX="$RELEASE_PATH/libgit2" .. \
-    && cmake --build . --target install)
+        -DCMAKE_INSTALL_PREFIX="$RELEASE_PATH/libgit2" ..
+  cmake --build . --target install
+  popd
 }
 
 function compile_git_seekrets() {
@@ -71,11 +128,15 @@ function compile_git_seekrets() {
   esac
 
   export GOARCH=amd64
-  export PKG_CONFIG_PATH=${RELEASE_PATH}/libgit2/lib/pkgconfig:${PKG_CONFIG_PATH}
+  export PKG_CONFIG_PATH="${RELEASE_PATH}/libgit2/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBGIT_PCFILE="${RELEASE_PATH}/libgit2/lib/pkgconfig/libgit2.pc"
-  FLAGS=$(pkg-config --static --libs "$LIBGIT_PCFILE") || exit 1
-  export CGO_LDFLAGS="${RELEASE_PATH}/libgit2/lib/libgit2.a -L${RELEASE_PATH}/libgit2/lib ${FLAGS}"
-  export CGO_CFLAGS="-I${RELEASE_PATH}/libgit2/include"
+  LIBGIT_FLAGS=$(pkg-config --static --libs "$LIBGIT_PCFILE") || exit 1
+  LIBCURL_FLAGS=$(pkg-config --static --libs "$LIBCURL_PCFILE") || exit 1
+  LIBSSL_FLAGS=$(pkg-config --static --libs "$LIBSSL_PCFILE") || exit 1
+  LIBCRYPTO_FLAGS=$(pkg-config --static --libs "$LIBCRYPTO_PCFILE") || exit 1
+  LIBSSH2_FLAGS=$(pkg-config --static --libs "$LIBSSH2_PCFILE") || exit 1
+  export CGO_LDFLAGS="$LIBGIT_FLAGS $LIBCURL_FLAGS $LIBSSL_FLAGS $LIBCRYPTO_FLAGS $LIBSSH2_FLAGS"
+  export CGO_CFLAGS="-I${RELEASE_PATH}/libgit2/include -I${RELEASE_PATH}/libssh2/include -I${RELEASE_PATH}/curl/include -I${RELEASE_PATH}/openssl/include"
   BINARY="$RELEASE_PATH/git-seekret-$SUFFIX"
   go build -tags static -ldflags "-linkmode external -extldflags '${CGO_LDFLAGS}'" -o "$BINARY"
   echo

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ function compile_openssl() {
   tar -xvf openssl-${OPENSSLVER}.tar.gz
   pushd openssl-${OPENSSLVER}
   export KERNEL_BITS=64
-  ./config no-shared no-ssl2 no-ssl3 --prefix=${RELEASE_PATH}/openssl --openssldir=${RELEASE_PATH}/openssl
+  ./config no-shared no-ssl2 no-ssl3 --prefix="${RELEASE_PATH}/openssl" --openssldir="${RELEASE_PATH}/openssl"
   make depend && make
   make install
   popd
@@ -57,7 +57,7 @@ function compile_libcurl() {
   pushd curl-${LIBCURLVER}
   export PKG_CONFIG_PATH="${RELEASE_PATH}/libssh2/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSH2_PCFILE="${RELEASE_PATH}/libssh2/lib/pkgconfig/libssh2.pc"
-  ./configure --with-ssl --with-libssh2 --disable-shared --prefix=${RELEASE_PATH}/curl
+  ./configure --with-ssl --with-libssh2 --disable-shared --prefix="${RELEASE_PATH}/curl"
   make && make install
   popd
 }

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,9 @@ function compile_libssh() {
   export PKG_CONFIG_PATH="${RELEASE_PATH}/openssl/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSL_PCFILE="${RELEASE_PATH}/openssl/lib/pkgconfig/libssl.pc"
   export LIBCRYPTO_PCFILE="${RELEASE_PATH}/openssl/lib/pkgconfig/libcrypto.pc"
-  ./configure --disable-shared --with-libssl-prefix="${RELEASE_PATH}/openssl" --prefix="${RELEASE_PATH}/libssh2"
+  LIBSSL_FLAGS=$(pkg-config --static --libs "$LIBSSL_PCFILE") || exit 1
+  LIBCRYPTO_FLAGS=$(pkg-config --static --libs "$LIBCRYPTO_PCFILE") || exit 1
+  LDFLAGS="${LIBSSL_FLAGS} ${LIBCRYPTO_FLAGS}" ./configure --disable-shared --with-libssl-prefix="${RELEASE_PATH}/openssl" --prefix="${RELEASE_PATH}/libssh2"
   make && make install
   popd
 }
@@ -57,7 +59,8 @@ function compile_libcurl() {
   pushd curl-${LIBCURLVER}
   export PKG_CONFIG_PATH="${RELEASE_PATH}/libssh2/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSH2_PCFILE="${RELEASE_PATH}/libssh2/lib/pkgconfig/libssh2.pc"
-  ./configure --with-ssl="${RELEASE_PATH}/openssl" --with-libssh2="${RELEASE_PATH}/libssh2" --without-librtmp --disable-ldap --disable-shared --prefix="${RELEASE_PATH}/curl"
+  LIBSSH2_FLAGS=$(pkg-config --static --libs "${LIBSSH2_PCFILE}") || exit 1
+  LDFLAGS="${LIBSSH2_FLAGS} ${LIBSSL_FLAGS} ${LIBCRYPTO_FLAGS}" ./configure --with-ssl="${RELEASE_PATH}/openssl" --with-libssh2="${RELEASE_PATH}/libssh2" --without-librtmp --disable-ldap --disable-shared --prefix="${RELEASE_PATH}/curl"
   make && make install
   popd
 }

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ function compile_libcurl() {
   pushd curl-${LIBCURLVER}
   export PKG_CONFIG_PATH="${RELEASE_PATH}/libssh2/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSH2_PCFILE="${RELEASE_PATH}/libssh2/lib/pkgconfig/libssh2.pc"
-  ./configure --with-ssl --with-libssh2 --without-librtmp --disable-ldap --disable-shared --prefix="${RELEASE_PATH}/curl"
+  ./configure --with-ssl="${RELEASE_PATH}/openssl" --with-libssh2="${RELEASE_PATH}/libssh2" --without-librtmp --disable-ldap --disable-shared --prefix="${RELEASE_PATH}/curl"
   make && make install
   popd
 }

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ function compile_openssl() {
   if [ ! -f openssl-1.0.2j.tar.gz ]; then
     curl -L -o openssl-${OPENSSLVER}.tar.gz https://www.openssl.org/source/openssl-${OPENSSLVER}.tar.gz
   fi
-  tar -xvf openssl-${OPENSSLVER}.tar.gz
+  tar -xzf openssl-${OPENSSLVER}.tar.gz
   pushd openssl-${OPENSSLVER}
   export KERNEL_BITS=64
   ./config no-shared no-ssl2 no-ssl3 --prefix="${RELEASE_PATH}/openssl" --openssldir="${RELEASE_PATH}/openssl"
@@ -55,7 +55,7 @@ function compile_libcurl() {
   if [ ! -f curl-${LIBCURLVER}.tar.gz ]; then
     curl -L -o curl-${LIBCURLVER}.tar.gz https://curl.haxx.se/download/curl-${LIBCURLVER}.tar.gz
   fi
-  tar -xvf curl-${LIBCURLVER}.tar.gz
+  tar -xzf curl-${LIBCURLVER}.tar.gz
   pushd curl-${LIBCURLVER}
   export PKG_CONFIG_PATH="${RELEASE_PATH}/libssh2/lib/pkgconfig:${PKG_CONFIG_PATH}"
   export LIBSSH2_PCFILE="${RELEASE_PATH}/libssh2/lib/pkgconfig/libssh2.pc"

--- a/glide.lock
+++ b/glide.lock
@@ -11,7 +11,7 @@ imports:
 - name: github.com/emptyinterface/sshconfig
   version: 9c4bfc0173e290759f33f37c0dcdb9af924be939
 - name: github.com/libgit2/git2go
-  version: 1c8297ab834aa3ca5f3c4128ded2758a680a9e60
+  version: 334260d743d713a55ff3c097ec6707f2bb39e9d5
 - name: github.com/urfave/cli
   version: 0bdeddeeb0f650497d603c4ad7b20cfe685682f6
 - name: gopkg.in/yaml.v2


### PR DESCRIPTION
- Update libgit2 to 0.25
- Make sure we're turning on more static compile flags
- temporarily, upload artifacts to S3 bucket provisioned in cloud.gov
- stub out github release deployment that should be used in future
- include all the proper library dependencies at statically compiled versions